### PR TITLE
fix error handling for nil font_descriptor

### DIFF
--- a/lib/pdf/extract/font_metrics.rb
+++ b/lib/pdf/extract/font_metrics.rb
@@ -40,9 +40,15 @@ module PdfExtract
         }
       else
         font_descriptor = font.font_descriptor
-        @ascent = font_descriptor.ascent
-        @descent = font_descriptor.descent
-        @bbox = font_descriptor.font_bounding_box
+        unless font_descriptor.nil?
+          @ascent = font_descriptor.ascent
+          @descent = font_descriptor.descent
+          @bbox = font_descriptor.font_bounding_box
+        else
+          # pdf-reader will initialize new Font objects with font_descriptor = nil
+          # if the font is a CID font. So "ascent", etc. throws a NoMethodError.
+          0
+        end
         @glyph_width_lookup = proc do |c|
           begin
             font.glyph_width(c.codepoints.first) || 0


### PR DESCRIPTION
In `pdf-reader` the font_descriptor variable is assigned here: [link](https://github.com/yob/pdf-reader/blob/master/lib/pdf/reader/font.rb#L141-L150)

Apparently for CID fonts it will be assigned `nil`. This can cause problems in `extract/font_metrics.rb` when trying to run the `ascent`/`descent` methods on a nil object, and throws this error:

```
pdf-extract-0.1.1/lib/pdf/extract/font_metrics.rb:44:in `initialize': undefined method `ascent' for nil:NilClass (NoMethodError)
```

This will at least allow it to continue running if it encounters a CID font.
