### PR TITLE
change from search.labs.crossref.org to search.crossref.org

### DIFF
--- a/lib/pdf/extract/references/resolve.rb
+++ b/lib/pdf/extract/references/resolve.rb
@@ -10,7 +10,7 @@ module PdfExtract::Resolve
 
     def self.find ref
       resolved = {:doi => nil, :score => nil}
-      url = "http://search.labs.crossref.org/dois?q=#{CGI.escape(ref)}&rows=1"
+      url = "http://search.crossref.org/dois?q=#{CGI.escape(ref)}&rows=1"
       query = JSON.parse(open(url).read())
       unless query.nil? or query[0].nil?
         resolved[:doi] = query[0]["doi"].sub "http://dx.doi.org/",""


### PR DESCRIPTION
Looks like the URL for reference resolution changed a little bit ... is this right?
