### PR TITLE
Fixing undefined method [] for nil:NilClass error

### DIFF
--- a/lib/pdf/extract/analysis/titles.rb
+++ b/lib/pdf/extract/analysis/titles.rb
@@ -27,14 +27,18 @@ module PdfExtract
 
           #   be no less tall than a factor of the tallest text,
           titles.sort_by! { |r| -r[:line_height] }
-          tallest_line = titles.first[:line_height]
-          title_slop = tallest_line - (tallest_line * pdf.settings[:title_slop])
-          titles.reject! { |r| r[:line_height] < title_slop }
+          if not titles.count.zero?
+            tallest_line = titles.first[:line_height]
+            title_slop = tallest_line - (tallest_line * pdf.settings[:title_slop])
+            titles.reject! { |r| r[:line_height] < title_slop }
+          end
           
           #   be on the earliest page with text,
           titles.sort_by! { |r| r[:page] }
-          first_page = titles.first[:page]
-          titles.reject! { |r| r[:page] != first_page }
+          if not titles.count.zero?
+            first_page = titles.first[:page]
+            titles.reject! { |r| r[:page] != first_page }
+          end
 
           #   be the highest of the above.
           titles.sort_by! { |r| -r[:y] }


### PR DESCRIPTION
When extracting some PDF papers you can get the `error: undefined method []' for nil:NilClass` error on `lib/analysis/titles.rb` file on line 30. The fix is to verify before if there is some title inside `titles` variable before check.